### PR TITLE
Changed markdownToAtlassianWikiMarkup options type

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,12 @@ yarn add @kenchan0130/markdown-to-atlassian-wiki-markup
 
 ## Usage
 
-```js
-// ES5
-const markdownToAtlassianWikiMarkup = require("@kenchan0130/markdown-to-atlassian-wiki-markup").markdownToAtlassianWikiMarkup;
-
-// TypeScript
-import { markdownToAtlassianWikiMarkup } from "@kenchan0130/markdown-to-atlassian-wiki-markup";
-```
+### Usage JavaScript
 
 ```js
-const wikiMarkup = markdownToAtlassianWikiMarkup("# Heading 1\n- list");
+var markdownToAtlassianWikiMarkup = require("@kenchan0130/markdown-to-atlassian-wiki-markup").markdownToAtlassianWikiMarkup;
+
+var wikiMarkup = markdownToAtlassianWikiMarkup("# Heading 1\n- list");
 console.log(wikiMarkup);
 /**
 h1. Heading
@@ -56,52 +52,142 @@ h1. Heading
 **/
 ```
 
-### Options
+### Usage TypeScript
+
+```typescript
+import { markdownToAtlassianWikiMarkup } from "@kenchan0130/markdown-to-atlassian-wiki-markup";
+console.log(wikiMarkup);
+/**
+h1. Heading
+
+* list
+
+**/
+```
+
+## Options
 
 You can use `MarkdownToAtlassianWikiMarkupOptions`.
 It has following properties.
 
-namespace|key|type|description
----|---|---|---
-codeBlock|theme|`CodeBlockTheme` or `string`|Theme of code block.<br>See also: https://confluence.atlassian.com/doc/code-block-macro-139390.html
-codeBlock|showLineNumbers|`boolean` or `(code: string, lang: AtlassianSupportLanguage) => boolean` function or `(code: string, lang: string) => boolean` function |Show or not linenumbers of code block.
-codeBlock|collapse|`boolean` or `(code: string, lang: AtlassianSupportLanguage) => boolean` function or `(code: string, lang: string) => boolean` function|Enable or not collapse of code block.
+| namespace | key             | type                                                                                                                                    | description                                                                                                                                                              |
+|-----------|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| codeBlock | theme           | `CodeBlockTheme` or `string`                                                                                                            | Theme of code block.<br>See also: [https://confluence.atlassian.com/doc/code-block-macro-139390.html](https://confluence.atlassian.com/doc/code-block-macro-139390.html) |
+| codeBlock | showLineNumbers | `boolean` or `(code: string, lang: AtlassianSupportLanguage) => boolean` function or `(code: string, lang: string) => boolean` function | Show or not linenumbers of code block.                                                                                                                                   |
+| codeBlock | collapse        | `boolean` or `(code: string, lang: AtlassianSupportLanguage) => boolean` function or `(code: string, lang: string) => boolean` function | Enable or not collapse of code block.                                                                                                                                    |
 
+### Options JavaScript Example
+
+```js
+var markdownToAtlassianWikiMarkup = require("@kenchan0130/markdown-to-atlassian-wiki-markup").markdownToAtlassianWikiMarkup;
+
+var options = {
+  codeBlock: {
+    theme: "DJango",
+    showLineNumbers: true,
+    collapse: true
+  }
+};
+var wikiMarkup = markdownToAtlassianWikiMarkup(`
+\`\`\`javascript
+console.log("This is JavaScript.");
+\`\`\`
+`, options);
+console.log(wikiMarkup);
+/*
+
+{code:collapse=true|language=javascript|linenumbers=true|theme=DJango}
+console.log("This is JavaScript.");
+{code}
+
+*/
+```
+
+```js
+var markdownToAtlassianWikiMarkup = require("@kenchan0130/markdown-to-atlassian-wiki-markup").markdownToAtlassianWikiMarkup;
+
+const options = {
+  codeBlock: {
+    theme: "DJango",
+    // In this case, it does not display line numbers when the code lang is none.
+    showLineNumbers: function(_code, lang) { return lang !== "none"; },
+    // In this case, it makes code block collapsed when the code line number more than 10.
+    collapse: function(code) { return code.split("\n").length > 10; },
+  }
+});
+var wikiMarkup = markdownToAtlassianWikiMarkup(```
+\`\`\`typescript
+console.log("This is TypeScript.");
+\`\`\`
+```, options);
+console.log(wikiMarkup);
+/*
+
+{code:collapse=false|language=none|linenumbers=false|theme=DJango}
+console.log("This is TypeScript.");
+{code}
+
+*/
+```
+
+### Options TypeScript Example
 
 ```typescript
-import { AtlassianSupportLanguage, CodeBlockTheme, MarkdownToAtlassianWikiMarkupOptions } from "@kenchan0130/markdown-to-atlassian-wiki-markup";
+import { AtlassianSupportLanguage, CodeBlockTheme, markdownToAtlassianWikiMarkup, MarkdownToAtlassianWikiMarkupOptions } from "@kenchan0130/markdown-to-atlassian-wiki-markup";
 
-const options = new MarkdownToAtlassianWikiMarkupOptions({
+const options = {
   codeBlock: {
     theme: CodeBlockTheme.DJango,
     showLineNumbers: true,
     collapse: true
   }
-});
-const wikiMarkup = markdownToAtlassianWikiMarkup("# Heading 1\n- list", options);
+};
+const wikiMarkup = markdownToAtlassianWikiMarkup(`
+\`\`\`javascript
+console.log("This is JavaScript.");
+\`\`\`
+`, options);
 console.log(wikiMarkup);
+/*
+
+{code:collapse=true|language=javascript|linenumbers=true|theme=DJango}
+console.log("This is JavaScript.");
+{code}
+
+*/
 ```
 
 ```typescript
-import { AtlassianSupportLanguage, CodeBlockTheme, MarkdownToAtlassianWikiMarkupOptions } from "@kenchan0130/markdown-to-atlassian-wiki-markup";
+import { AtlassianSupportLanguage, CodeBlockTheme, markdownToAtlassianWikiMarkup, MarkdownToAtlassianWikiMarkupOptions } from "@kenchan0130/markdown-to-atlassian-wiki-markup";
 
-const options = new MarkdownToAtlassianWikiMarkupOptions({
+const options = {
   codeBlock: {
     theme: CodeBlockTheme.DJango,
     // In this case, it does not display line numbers when the code lang is none.
     showLineNumbers: (
-      code: string,
-      _lang: AtlassianSupportLanguage
+      _code: string,
+      lang: AtlassianSupportLanguage
     ): boolean => lang !== AtlassianSupportLanguage.None,
     // In this case, it makes code block collapsed when the code line number more than 10.
     collapse: (
-      _code: string,
-      lang: AtlassianSupportLanguage
+      code: string,
+      _lang: AtlassianSupportLanguage
     ): boolean => code.split("\n").length > 10,
   }
 });
-const wikiMarkup = markdownToAtlassianWikiMarkup("# Heading 1\n- list", options);
+const wikiMarkup = markdownToAtlassianWikiMarkup(```
+\`\`\`typescript
+console.log("This is TypeScript.");
+\`\`\`
+```, options);
 console.log(wikiMarkup);
+/*
+
+{code:collapse=false|language=none|linenumbers=false|theme=DJango}
+console.log("This is TypeScript.");
+{code}
+
+*/
 ```
 
 ## About Markdown

--- a/src/atlassianWikiMarkupRenderer.ts
+++ b/src/atlassianWikiMarkupRenderer.ts
@@ -16,33 +16,16 @@ export enum CodeBlockTheme {
   Confluence = "Confluence"
 }
 
-export class MarkdownToAtlassianWikiMarkupOptions {
-  public codeBlockTheme?: CodeBlockTheme;
-  public showCodeBlockLineNumbers?:
-    | boolean
-    | ((code: string, lang: AtlassianSupportLanguage) => boolean);
-  public collapse?:
-    | boolean
-    | ((code: string, lang: AtlassianSupportLanguage) => boolean);
-
-  public constructor(params: {
-    codeBlock?: {
-      theme?: CodeBlockTheme;
-      showLineNumbers?:
-        | boolean
-        | ((code: string, lang: AtlassianSupportLanguage) => boolean);
-      collapse?:
-        | boolean
-        | ((code: string, lang: AtlassianSupportLanguage) => boolean);
-    };
-  }) {
-    this.codeBlockTheme =
-      (params.codeBlock && params.codeBlock.theme) || undefined;
-    this.showCodeBlockLineNumbers =
-      (params.codeBlock && params.codeBlock.showLineNumbers) || undefined;
-    this.collapse =
-      (params.codeBlock && params.codeBlock.collapse) || undefined;
-  }
+export interface MarkdownToAtlassianWikiMarkupOptions {
+  codeBlock?: {
+    theme?: CodeBlockTheme;
+    showLineNumbers?:
+      | boolean
+      | ((code: string, lang: AtlassianSupportLanguage) => boolean);
+    collapse?:
+      | boolean
+      | ((code: string, lang: AtlassianSupportLanguage) => boolean);
+  };
 }
 
 enum ListHeadCharacter {
@@ -257,7 +240,9 @@ export class AtlassianWikiMarkupRenderer extends Renderer {
 
   public code(code: string, language: string, _isEscaped: boolean): string {
     const theme =
-      (this.rendererOptions && this.rendererOptions.codeBlockTheme) ||
+      (this.rendererOptions &&
+        this.rendererOptions.codeBlock &&
+        this.rendererOptions.codeBlock.theme) ||
       CodeBlockTheme.Confluence;
 
     const usingLang =
@@ -266,28 +251,28 @@ export class AtlassianWikiMarkupRenderer extends Renderer {
 
     const isDisplayLinenumbers = ((): boolean => {
       const defaultValue = false;
-      if (!this.rendererOptions) {
+      if (!this.rendererOptions || !this.rendererOptions.codeBlock) {
         return defaultValue;
       }
 
-      if (this.rendererOptions.showCodeBlockLineNumbers instanceof Function) {
-        return this.rendererOptions.showCodeBlockLineNumbers(code, usingLang);
+      if (this.rendererOptions.codeBlock.showLineNumbers instanceof Function) {
+        return this.rendererOptions.codeBlock.showLineNumbers(code, usingLang);
       }
 
-      return this.rendererOptions.showCodeBlockLineNumbers || defaultValue;
+      return this.rendererOptions.codeBlock.showLineNumbers || defaultValue;
     })();
 
     const isCollapseCodeBlock = ((): boolean => {
       const defaultValue = false;
-      if (!this.rendererOptions) {
+      if (!this.rendererOptions || !this.rendererOptions.codeBlock) {
         return defaultValue;
       }
 
-      if (this.rendererOptions.collapse instanceof Function) {
-        return this.rendererOptions.collapse(code, usingLang);
+      if (this.rendererOptions.codeBlock.collapse instanceof Function) {
+        return this.rendererOptions.codeBlock.collapse(code, usingLang);
       }
 
-      return this.rendererOptions.collapse || defaultValue;
+      return this.rendererOptions.codeBlock.collapse || defaultValue;
     })();
 
     const params = {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,8 +1,4 @@
-import {
-  CodeBlockTheme,
-  markdownToAtlassianWikiMarkup,
-  MarkdownToAtlassianWikiMarkupOptions
-} from "./index";
+import { CodeBlockTheme, markdownToAtlassianWikiMarkup } from "./index";
 import { AtlassianSupportLanguage } from "./language";
 
 describe("markdownToAtlassianWikiMarkup", (): void => {
@@ -394,11 +390,11 @@ describe("markdownToAtlassianWikiMarkup Options", (): void => {
   describe("codeBlockTheme", (): void => {
     it("should use specified code block theme", (): void => {
       const theme = CodeBlockTheme.Midnight;
-      const options = new MarkdownToAtlassianWikiMarkupOptions({
+      const options = {
         codeBlock: {
           theme: theme
         }
-      });
+      };
 
       const markdown = `
 \`\`\`javascript
@@ -432,11 +428,11 @@ helloWorld();
 `;
 
     it("should use specified code block used linenumber or not", (): void => {
-      const options = new MarkdownToAtlassianWikiMarkupOptions({
+      const options = {
         codeBlock: {
           showLineNumbers: true
         }
-      });
+      };
 
       const expected = `{code:collapse=false|language=javascript|linenumbers=true|theme=Confluence}
 const helloWorld = () => {
@@ -451,7 +447,7 @@ helloWorld();
     });
 
     it("should use specified code block used linenumber or not with function", (): void => {
-      const options = new MarkdownToAtlassianWikiMarkupOptions({
+      const options = {
         codeBlock: {
           showLineNumbers: (
             _code: string,
@@ -460,7 +456,7 @@ helloWorld();
             return true;
           }
         }
-      });
+      };
 
       const expected = `{code:collapse=false|language=javascript|linenumbers=true|theme=Confluence}
 const helloWorld = () => {
@@ -486,11 +482,11 @@ helloWorld();
 `;
 
     it("should use specified code block used collapse or not", (): void => {
-      const options = new MarkdownToAtlassianWikiMarkupOptions({
+      const options = {
         codeBlock: {
           collapse: true
         }
-      });
+      };
 
       const expected = `{code:collapse=true|language=javascript|linenumbers=false|theme=Confluence}
 const helloWorld = () => {
@@ -505,7 +501,7 @@ helloWorld();
     });
 
     it("should use specified code block used collapse or not with function", (): void => {
-      const options = new MarkdownToAtlassianWikiMarkupOptions({
+      const options = {
         codeBlock: {
           collapse: (
             _code: string,
@@ -514,7 +510,7 @@ helloWorld();
             return true;
           }
         }
-      });
+      };
 
       const expected = `{code:collapse=true|language=javascript|linenumbers=false|theme=Confluence}
 const helloWorld = () => {


### PR DESCRIPTION
Since it is not common to make an option a class, it has been changed to interface.
