### PR TITLE
Build target to ES2018

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4198,9 +4198,9 @@
       }
     },
     "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
+      "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ=="
     },
     "memorystream": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@types/marked": "^0.7.0",
     "escape-string-regexp": "^2.0.0",
-    "marked": "^0.7.0",
+    "marked": "^0.8.0",
     "ts-polyfill": "^3.8.1-rc"
   },
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2018",
     "lib": ["es2019"],
     "module": "commonjs",
     "strict": true,


### PR DESCRIPTION
## Motivation

We don't know if [marked](https://github.com/markedjs/marked) is supported for es5 syntax, but we want to use a target that can use the new syntax and features because we want to apply the latest version.

See also: https://github.com/kenchan0130/markdown-to-atlassian-wiki-markup/pull/88

## Changes

- If you want to use this with a browser, etc., you may need to polyfill and transpile using [Babel](https://babeljs.io/) etc.
- Bump up [marked](https://github.com/markedjs/marked) to 0.8.0