### PR TITLE
Adjust enum codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ It has following properties.
 | namespace | key             | type                                                                                    | description                                                                                                                                                              |
 |-----------|-----------------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | codeBlock | theme           | `CodeBlockTheme` or `string`                                                            | Theme of code block.<br>See also: [https://confluence.atlassian.com/doc/code-block-macro-139390.html](https://confluence.atlassian.com/doc/code-block-macro-139390.html) |
-| codeBlock | showLineNumbers | `boolean` or `(code: string, lang: AtlassianSupportLanguageValues) => boolean` function | Show or not linenumbers of code block.                                                                                                                                   |
-| codeBlock | collapse        | `boolean` or `(code: string, lang: AtlassianSupportLanguageValues) => boolean` function | Enable or not collapse of code block.                                                                                                                                    |
+| codeBlock | showLineNumbers | `boolean` or `(code: string, lang: AtlassianSupportLanguage) => boolean` function | Show or not linenumbers of code block.                                                                                                                                   |
+| codeBlock | collapse        | `boolean` or `(code: string, lang: AtlassianSupportLanguage) => boolean` function | Enable or not collapse of code block.                                                                                                                                    |
 
 ### Options JavaScript Example
 
@@ -162,7 +162,7 @@ console.log("This is JavaScript.");
 ```
 
 ```typescript
-import { AtlassianSupportLanguage, AtlassianSupportLanguageValues, CodeBlockTheme, markdownToAtlassianWikiMarkup, MarkdownToAtlassianWikiMarkupOptions } from "@kenchan0130/markdown-to-atlassian-wiki-markup";
+import { AtlassianSupportLanguage, CodeBlockTheme, markdownToAtlassianWikiMarkup, MarkdownToAtlassianWikiMarkupOptions } from "@kenchan0130/markdown-to-atlassian-wiki-markup";
 
 const options = {
   codeBlock: {
@@ -170,12 +170,12 @@ const options = {
     // In this case, it does not display line numbers when the code lang is none.
     showLineNumbers: (
       _code: string,
-      lang: AtlassianSupportLanguageValues
+      lang: AtlassianSupportLanguage
     ): boolean => lang !== AtlassianSupportLanguage.None,
     // In this case, it makes code block collapsed when the code line number more than 10.
     collapse: (
       code: string,
-      _lang: AtlassianSupportLanguageValues
+      _lang: AtlassianSupportLanguage
     ): boolean => code.split("\n").length > 10,
   }
 });

--- a/src/atlassianWikiMarkupRenderer.ts
+++ b/src/atlassianWikiMarkupRenderer.ts
@@ -3,20 +3,10 @@ import { Renderer, Slugger } from "marked";
 
 import {
   AtlassianSupportLanguage,
-  AtlassianSupportLanguageValues,
   markdownToWikiMarkupLanguageMapping,
 } from "./language";
 
-type CodeBlockTheme = {
-  DJango: "DJango";
-  Emacs: "Emacs";
-  FadeToGrey: "FadeToGrey";
-  Midnight: "Midnight";
-  RDark: "RDark";
-  Eclipse: "Eclipse";
-  Confluence: "Confluence";
-};
-export const CodeBlockTheme: CodeBlockTheme = {
+export const CodeBlockTheme = {
   DJango: "DJango",
   Emacs: "Emacs",
   FadeToGrey: "FadeToGrey",
@@ -24,18 +14,18 @@ export const CodeBlockTheme: CodeBlockTheme = {
   RDark: "RDark",
   Eclipse: "Eclipse",
   Confluence: "Confluence",
-};
-export type CodeBlockThemeValues = CodeBlockTheme[keyof CodeBlockTheme];
+} as const;
+type CodeBlockTheme = typeof CodeBlockTheme[keyof typeof CodeBlockTheme];
 
 export type MarkdownToAtlassianWikiMarkupOptions = {
   codeBlock?: {
-    theme?: CodeBlockThemeValues;
+    theme?: CodeBlockTheme;
     showLineNumbers?:
       | boolean
-      | ((code: string, lang: AtlassianSupportLanguageValues) => boolean);
+      | ((code: string, lang: AtlassianSupportLanguage) => boolean);
     collapse?:
       | boolean
-      | ((code: string, lang: AtlassianSupportLanguageValues) => boolean);
+      | ((code: string, lang: AtlassianSupportLanguage) => boolean);
   };
 };
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,8 +1,5 @@
-import {
-  AtlassianSupportLanguageValues,
-  CodeBlockTheme,
-  markdownToAtlassianWikiMarkup,
-} from "./index";
+import { AtlassianSupportLanguage } from "./language";
+import { CodeBlockTheme, markdownToAtlassianWikiMarkup } from "./index";
 
 describe("markdownToAtlassianWikiMarkup", () => {
   const paragraphNewLinesAtTail = "\n\n";
@@ -455,7 +452,7 @@ helloWorld();
         codeBlock: {
           showLineNumbers: (
             _code: string,
-            _lang: AtlassianSupportLanguageValues
+            _lang: AtlassianSupportLanguage
           ): boolean => true,
         },
       };
@@ -505,10 +502,8 @@ helloWorld();
     it("should use specified code block used collapse or not with function", () => {
       const options = {
         codeBlock: {
-          collapse: (
-            _code: string,
-            _lang: AtlassianSupportLanguageValues
-          ): boolean => true,
+          collapse: (_code: string, _lang: AtlassianSupportLanguage): boolean =>
+            true,
         },
       };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,13 +9,9 @@ export {
   AtlassianWikiMarkupRenderer,
   MarkdownToAtlassianWikiMarkupOptions,
   CodeBlockTheme,
-  CodeBlockThemeValues,
 } from "./atlassianWikiMarkupRenderer";
 
-export {
-  AtlassianSupportLanguage,
-  AtlassianSupportLanguageValues,
-} from "./language";
+export { AtlassianSupportLanguage } from "./language";
 
 export const markdownToAtlassianWikiMarkup = (
   markdown: string,

--- a/src/language.ts
+++ b/src/language.ts
@@ -1,47 +1,6 @@
 import "ts-polyfill/lib/es2019-array"; // It will be removed when node 10 is stopped supporting (become EOL).
 
-type SupportLanguage = {
-  ActionScript: "actionscript";
-  Ada: "ada";
-  AppleScript: "applescript";
-  Bash: "bash";
-  C: "c";
-  CSharp: "c#";
-  CPlusPlus: "c++";
-  CSS: "css";
-  Erlang: "erlang";
-  Go: "go";
-  Groovy: "groovy";
-  Haskell: "haskell";
-  HTML: "html";
-  Java: "java";
-  JavaScript: "javascript";
-  JSON: "json";
-  Lua: "lua";
-  Nyan: "nyan";
-  ObjectiveC: "objc";
-  Perl: "perl";
-  PHP: "php";
-  PowerShell: "powershell";
-  Python: "python";
-  R: "r";
-  Ruby: "ruby";
-  Sass: "sass";
-  Scala: "scala";
-  SQL: "sql";
-  Swift: "swift";
-  VisualBasic: "visualbasic";
-  XML: "xml";
-  YAML: "yaml";
-};
-
-type SupportLanguageValues = SupportLanguage[keyof SupportLanguage];
-
-type AtlassianSupportLanguage = SupportLanguage & { None: "none" };
-export type AtlassianSupportLanguageValues = AtlassianSupportLanguage[keyof AtlassianSupportLanguage];
-
-// See also: https://confluence.atlassian.com/doc/code-block-macro-139390.html, https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=advanced
-export const AtlassianSupportLanguage: AtlassianSupportLanguage = {
+const SupportLanguage = {
   ActionScript: "actionscript",
   Ada: "ada",
   AppleScript: "applescript",
@@ -59,7 +18,6 @@ export const AtlassianSupportLanguage: AtlassianSupportLanguage = {
   JavaScript: "javascript",
   JSON: "json",
   Lua: "lua",
-  None: "none",
   Nyan: "nyan",
   ObjectiveC: "objc",
   Perl: "perl",
@@ -75,10 +33,21 @@ export const AtlassianSupportLanguage: AtlassianSupportLanguage = {
   VisualBasic: "visualbasic",
   XML: "xml",
   YAML: "yaml",
-};
+} as const;
+type SupportLanguage = typeof SupportLanguage[keyof typeof SupportLanguage];
+
+/**
+ * See also: https://confluence.atlassian.com/doc/code-block-macro-139390.html
+ *           https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=advanced
+ */
+export const AtlassianSupportLanguage = {
+  None: "none",
+  ...SupportLanguage,
+} as const;
+export type AtlassianSupportLanguage = typeof AtlassianSupportLanguage[keyof typeof AtlassianSupportLanguage];
 
 type GitHubFlaveredMarkdownCodeBlockLanguageMapping = {
-  [P in keyof SupportLanguage]: string[];
+  [P in keyof typeof SupportLanguage]: string[];
 };
 
 // See also: https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
@@ -271,7 +240,7 @@ export const GitHubFlaveredMarkdownCodeBlockLanguageMapping: GitHubFlaveredMarkd
 
 export const markdownToWikiMarkupLanguageMapping: Map<
   string,
-  SupportLanguageValues
+  SupportLanguage
 > = new Map(
   Object.entries(GitHubFlaveredMarkdownCodeBlockLanguageMapping).flatMap(
     ([key, langs]) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2018",
-    "lib": ["es2019"],
+    "target": "es2015",
+    "lib": ["esnext"],
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
We can simplify the handling of enums by using "as const".

It used to be written in a verbose way, but by simplifying it, users and developers can now handle enums intuitively.