### PR TITLE
Some library dependencies have been removed.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,26 +10,25 @@
       "license": "MIT",
       "dependencies": {
         "@types/marked": "latest",
-        "escape-string-regexp": "*",
-        "marked": "*"
+        "escape-string-regexp": "latest",
+        "marked": "latest"
       },
       "devDependencies": {
-        "@types/array-unique": "*",
-        "@types/jest": "*",
-        "@types/node": "*",
-        "@typescript-eslint/eslint-plugin": "*",
-        "@typescript-eslint/parser": "*",
-        "array-unique": "*",
-        "eslint": "*",
-        "eslint-config-prettier": "*",
-        "eslint-plugin-jest": "*",
-        "eslint-plugin-prettier": "*",
-        "jest": "*",
-        "npm-run-all": "*",
-        "prettier": "*",
-        "rimraf": "*",
-        "ts-jest": "*",
-        "typescript": "*"
+        "@types/array-unique": "latest",
+        "@types/jest": "latest",
+        "@types/node": "latest",
+        "@typescript-eslint/eslint-plugin": "latest",
+        "@typescript-eslint/parser": "latest",
+        "eslint": "latest",
+        "eslint-config-prettier": "latest",
+        "eslint-plugin-jest": "latest",
+        "eslint-plugin-prettier": "latest",
+        "jest": "latest",
+        "npm-run-all": "latest",
+        "prettier": "latest",
+        "rimraf": "latest",
+        "ts-jest": "latest",
+        "typescript": "latest"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1007,9 +1006,9 @@
       "dev": true
     },
     "node_modules/@types/marked": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-2.0.3.tgz",
-      "integrity": "sha512-lbhSN1rht/tQ+dSWxawCzGgTfxe9DB31iLgiT1ZVT5lshpam/nyOA1m3tKHRoNPctB2ukSL22JZI5Fr+WI/zYg=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-2.0.2.tgz",
+      "integrity": "sha512-P4zanhCQKs4tiWPPBGpB7lHflgFCP9DFGNI5YtpW9MALKoy2qs9rHNWJ+z55cegD9uCfnmsKuaosq9FNvbxrOw=="
     },
     "node_modules/@types/node": {
       "version": "14.14.37",
@@ -2420,11 +2419,14 @@
       }
     },
     "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/escodegen": {
@@ -4909,9 +4911,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.7.tgz",
-      "integrity": "sha512-BJXxkuIfJchcXOJWTT2DOL+yFWifFv2yGYOUzvXg8Qz610QKw+sHCvTMYwA+qWGhlA2uivBezChZ/pBy1tWdkQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
+      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
       "bin": {
         "marked": "bin/marked"
       },
@@ -8413,9 +8415,9 @@
       "dev": true
     },
     "@types/marked": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-2.0.3.tgz",
-      "integrity": "sha512-lbhSN1rht/tQ+dSWxawCzGgTfxe9DB31iLgiT1ZVT5lshpam/nyOA1m3tKHRoNPctB2ukSL22JZI5Fr+WI/zYg=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-2.0.2.tgz",
+      "integrity": "sha512-P4zanhCQKs4tiWPPBGpB7lHflgFCP9DFGNI5YtpW9MALKoy2qs9rHNWJ+z55cegD9uCfnmsKuaosq9FNvbxrOw=="
     },
     "@types/node": {
       "version": "14.14.37",
@@ -9567,9 +9569,9 @@
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
     },
     "escodegen": {
       "version": "1.14.3",
@@ -11567,9 +11569,9 @@
       }
     },
     "marked": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.7.tgz",
-      "integrity": "sha512-BJXxkuIfJchcXOJWTT2DOL+yFWifFv2yGYOUzvXg8Qz610QKw+sHCvTMYwA+qWGhlA2uivBezChZ/pBy1tWdkQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
+      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw=="
     },
     "memorystream": {
       "version": "0.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/marked": "latest",
-        "escape-string-regexp": "latest",
         "marked": "latest"
       },
       "devDependencies": {
@@ -9569,8 +9568,7 @@
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
     },
     "escodegen": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@types/node": "latest",
     "@typescript-eslint/eslint-plugin": "latest",
     "@typescript-eslint/parser": "latest",
-    "array-unique": "latest",
     "eslint": "latest",
     "eslint-config-prettier": "latest",
     "eslint-plugin-jest": "latest",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   ],
   "dependencies": {
     "@types/marked": "latest",
-    "escape-string-regexp": "latest",
     "marked": "latest"
   },
   "devDependencies": {

--- a/src/atlassianWikiMarkupRenderer.ts
+++ b/src/atlassianWikiMarkupRenderer.ts
@@ -1,6 +1,5 @@
 import escapeStringRegexp from "escape-string-regexp";
 import { Renderer, Slugger } from "marked";
-
 import {
   AtlassianSupportLanguage,
   markdownToWikiMarkupLanguageMapping,
@@ -15,7 +14,7 @@ export const CodeBlockTheme = {
   Eclipse: "Eclipse",
   Confluence: "Confluence",
 } as const;
-type CodeBlockTheme = typeof CodeBlockTheme[keyof typeof CodeBlockTheme];
+export type CodeBlockTheme = typeof CodeBlockTheme[keyof typeof CodeBlockTheme];
 
 export type MarkdownToAtlassianWikiMarkupOptions = {
   codeBlock?: {

--- a/src/atlassianWikiMarkupRenderer.ts
+++ b/src/atlassianWikiMarkupRenderer.ts
@@ -1,9 +1,9 @@
-import escapeStringRegexp from "escape-string-regexp";
 import { Renderer, Slugger } from "marked";
 import {
   AtlassianSupportLanguage,
   markdownToWikiMarkupLanguageMapping,
 } from "./language";
+import { escapeStringRegexp } from "./utils";
 
 export const CodeBlockTheme = {
   DJango: "DJango",

--- a/src/language.spec.ts
+++ b/src/language.spec.ts
@@ -1,9 +1,10 @@
-import { immutable as uniq } from "array-unique";
 import {
   AtlassianSupportLanguage,
   GitHubFlaveredMarkdownCodeBlockLanguageMapping,
   markdownToWikiMarkupLanguageMapping,
 } from "./language";
+
+const uniq = <T>(array: Array<T>): Array<T> => [...new Set(array)];
 
 describe("AtlassianSupportLanguage", () => {
   describe("enum values", () => {

--- a/src/language.spec.ts
+++ b/src/language.spec.ts
@@ -3,8 +3,7 @@ import {
   GitHubFlaveredMarkdownCodeBlockLanguageMapping,
   markdownToWikiMarkupLanguageMapping,
 } from "./language";
-
-const uniq = <T>(array: Array<T>): Array<T> => [...new Set(array)];
+import { uniq } from "./utils";
 
 describe("AtlassianSupportLanguage", () => {
   describe("enum values", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,6 @@
+// See also: https://github.com/sindresorhus/escape-string-regexp
+export const escapeStringRegexp = (s: string): string => {
+  return s.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&").replace(/-/g, "\\x2d");
+};
+
+export const uniq = <T>(array: Array<T>): Array<T> => [...new Set(array)];


### PR DESCRIPTION
- Drop escapeStringRegexp lib
   - I think it's too early to steer to ESM.
   - It's a simple implementation, so we could eliminate the dependency by preparing it ourselves.
- drop array-unique lib
   - Use `new Set` to substitute and eliminate dependency.  